### PR TITLE
issue/3 ie11 scaling fix

### DIFF
--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -8,7 +8,7 @@ define([
 
     initialize: function() {
       _.bindAll(this, "onScreenCallback");
-
+      this.listenTo(Adapt, 'device:resize', this.onResize);
       ComponentView.prototype.initialize.apply(this, arguments);
     },
 
@@ -18,9 +18,7 @@ define([
 
     postRender: function() {
       this.setUpAnimation();
-
       // window.anim = this.animation;
-
       this.animation.addEventListener("data_ready", this.onReady.bind(this));
     },
 
@@ -28,7 +26,7 @@ define([
       var config = this.model.get('_svg');
 
       this.animation = Lottie.loadAnimation({
-        container: this.$('.component__widget')[0],
+        container: this.$('.svg__widget-aligner')[0],
         renderer: config._renderer,
         loop: config._loop,
         autoplay: config._autoplay,
@@ -37,11 +35,34 @@ define([
     },
 
     onReady: function() {
+      this.onResize();
       this.setReadyStatus();
 
       // Bind 'inview' once the images are ready.
       this.$('.component__widget').on('inview', this.inview.bind(this));
       this.setOnScreen(true);
+    },
+
+    onResize: function() {
+      const $svg = this.$('svg');
+      const $aligner = this.$('.svg__widget-aligner');
+      this.dimensions = this.dimensions || {
+        height: parseInt($svg.attr('height')),
+        width: parseInt($svg.attr('width')),
+      };
+      const ratio = this.dimensions.height / this.dimensions.width;
+      const width = this.$el.width();
+      const height = width * ratio;
+      const scale = (1 / this.dimensions.width) * width;
+      $svg.css({
+        width: this.dimensions.width,
+        height: this.dimensions.height,
+        transform: `scale(${scale})`,
+        transformOrigin: 'top left'
+      });
+      $aligner.css({
+        height: height
+      });
     },
 
     checkIfResetOnRevisit: function() {

--- a/templates/svg.hbs
+++ b/templates/svg.hbs
@@ -2,6 +2,8 @@
 
   {{> component this}}
 
-  <div class="component__widget svg__widget"></div>
+  <div class="component__widget svg__widget">
+    <div class="svg__widget-aligner"></div>
+  </div>
 
 </div>


### PR DESCRIPTION
#3 

1. Let the svg keep its own size.
2. Use javascript on load and device:resize to:
3. Get the original height/width ratio of the svg as supplied by the height and width properties
4. Calculate how much the svg needs to be scaled by to fill the width of the component.
5. Apply scaling as a css transform with origin: top left
6. Add a container to keep the relative new calculated height after transformation.