### PR TITLE
Android width overflow fix

### DIFF
--- a/less/svg.less
+++ b/less/svg.less
@@ -1,0 +1,5 @@
+.svg {
+  &__widget-aligner {
+    overflow: hidden;
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/cgkineo/adapt-svg/issues/5

* Adds an `overflow: hidden;` to the SVG container element to resolve an Android width overflow bug.