### PR TITLE
Fix: Set aria-hidden when no alt or description is set (fixes #18)

### DIFF
--- a/templates/svg.hbs
+++ b/templates/svg.hbs
@@ -13,7 +13,7 @@
       {{/if}}
     </div>
     <div class="svg__animation">
-      <div class="svg__player{{#if _animation._showPauseControl}} js-svg-play-pause{{/if}}">
+      <div class="svg__player{{#if _animation._showPauseControl}} js-svg-play-pause{{/if}}"{{#any _animation.alt _animation.description}}{{else}} aria-hidden="true"{{/any}}>
         {{#if _animation.alt}}
         {{a11y_aria_image _animation.alt}}
         {{/if}}


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-svg/issues/18 
- both `alt` and `description` are rendered as `aria-label`s so we should check for either.
- `aria-hidden` applied to `.svg__player` as this contains the svg animation and associated controls.