### PR TITLE
Fix: Adds support for Visua11y's 'no animations' option (fixes #21)

### DIFF
--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -19,7 +19,8 @@ export default class SvgView extends ComponentView {
     this.update = _.throttle(this.update.bind(this), 17);
     this.isOnScreen = false;
     this.listenTo(Adapt, 'device:resize', this.onResize);
-    this.checkOriginalValues();
+    this.setUpOriginalValues();
+    this.resetToOriginalValues();
     this.checkIfResetOnRevisit();
   }
 
@@ -31,7 +32,7 @@ export default class SvgView extends ComponentView {
     this.setupInviewCompletion();
   }
 
-  checkOriginalValues() {
+  setUpOriginalValues() {
     const animationConfig = this.model.get('_animation');
     if (this.model.get('_originalShowPauseControl') === undefined) {
       this.model.set('_originalShowPauseControl', animationConfig._showPauseControl);
@@ -39,10 +40,14 @@ export default class SvgView extends ComponentView {
     if (this.model.get('_originalAutoPlay') === undefined) {
       this.model.set('_originalAutoPlay', animationConfig._autoPlay);
     }
-    if (!this.isPausedWithVisua11y) {
-      animationConfig._showPauseControl = this.model.get('_originalShowPauseControl');
-      animationConfig._autoPlay = this.model.get('_originalAutoPlay');
-    }
+  }
+
+  resetToOriginalValues() {
+    if (this.isPausedWithVisua11y) { return; }
+
+    const animationConfig = this.model.get('_animation');
+    animationConfig._showPauseControl = this.model.get('_originalShowPauseControl');
+    animationConfig._autoPlay = this.model.get('_originalAutoPlay');
   }
 
   setUpAnimation() {

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -200,7 +200,11 @@ export default class SvgView extends ComponentView {
     return (this.isPaused !== this.animation.isPaused);
   }
 
-  replay() {
+  restart() {
+    const animation = this.model.get('_animation');
+    animation._showPauseControl = this.model.get('_originalShowPauseControl');
+    animation._autoPlay = this.model.get('_originalAutoPlay');
+    this.toggleControls();
     this.animation.goToAndPlay(0);
     this.update();
   }
@@ -224,12 +228,8 @@ export default class SvgView extends ComponentView {
 
     // Check if animation should start playing again
     if (this.isPausedWithVisua11y && !shouldStopAnimations) {
-      const animation = this.model.get('_animation');
-      animation._showPauseControl = this.model.get('_originalShowPauseControl');
-      animation._autoPlay = this.model.get('_originalAutoPlay');
-      this.toggleControls();
       this.isPausedWithVisua11y = false;
-      this.replay();
+      this.restart();
       return;
     }
 

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -200,9 +200,10 @@ export default class SvgView extends ComponentView {
 
   goToEndAndStop() {
     const animation = this.model.get('_animation');
-    const lastFrame = this.animation.totalFrames - 1;
     animation._autoPlay = false;
     animation._showPauseControl = false;
+
+    const lastFrame = this.animation.totalFrames - 1;
     this.toggleControls();
     this.animation.goToAndStop(lastFrame, true);
     this.animation.pause();

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -111,7 +111,7 @@ export default class SvgView extends ComponentView {
     const isReducedMotion = (this.model.get('_isReducedMotionSupportEnabled') && this._reducedMotionQuery && this._reducedMotionQuery.matches);
     const animation = this.model.get('_animation');
     if (isReducedMotion) {
-      this.goToEndAndStop();
+      this.stopAtEnd();
       return;
     }
     animation._autoPlay = this.model.get('_originalAutoplay');
@@ -205,7 +205,7 @@ export default class SvgView extends ComponentView {
     this.update();
   }
 
-  goToEndAndStop() {
+  stopAtEnd() {
     const animation = this.model.get('_animation');
     animation._autoPlay = false;
     animation._showPauseControl = false;
@@ -235,7 +235,7 @@ export default class SvgView extends ComponentView {
 
     // Stop on last frame
     this.isPausedWithVisua11y = true;
-    this.goToEndAndStop();
+    this.stopAtEnd();
   }
 
   toggleControls() {

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -50,9 +50,7 @@ export default class SvgView extends ComponentView {
     this.animation.addEventListener('loopComplete', this.update);
     this.animation.addEventListener('enterFrame', this.update);
 
-    documentModifications.on('changed:html', event => {
-      this.checkVisua11y();
-    });
+    this.listenTo(documentModifications, 'changed:html', this.checkVisua11y);
   }
 
   onFail() {

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -1,6 +1,7 @@
 import Adapt from 'core/js/adapt';
 import ComponentView from 'core/js/views/componentView';
 import Lottie from 'libraries/lottie.min';
+import documentModifications from 'core/js/DOMElementModifications';
 
 export default class SvgView extends ComponentView {
 
@@ -22,6 +23,8 @@ export default class SvgView extends ComponentView {
 
   postRender() {
     this.setUpAnimation();
+    this.setUpListeners();
+
     if (this.model.get('_setCompletionOn') !== 'inview') return;
     this.setupInviewCompletion();
   }
@@ -38,11 +41,18 @@ export default class SvgView extends ComponentView {
       autoplay: false, // we'll use checkIfOnScreen to control when playback starts
       path: isSingleFile ? src : src + '/data.json'
     });
+  }
+
+  setUpListeners() {
     this.animation.addEventListener('data_ready', this.onReady);
     this.animation.addEventListener('data_failed', this.onFail);
     this.animation.addEventListener('complete', this.update);
     this.animation.addEventListener('loopComplete', this.update);
     this.animation.addEventListener('enterFrame', this.update);
+
+    documentModifications.on('changed:html', event => {
+      this.checkVisua11y();
+    });
   }
 
   onFail() {
@@ -189,6 +199,23 @@ export default class SvgView extends ComponentView {
 
   shouldUpdate() {
     return (this.isPaused !== this.animation.isPaused);
+  }
+
+  goToEndAndStop() {
+    // const lastFrame = this.animation.totalFrames - 1;
+    // this.animation.loop = 0;
+    // this.animation.goToAndStop(lastFrame, true);
+    // this.showControls = false;
+    // this.pause();
+  }
+
+  checkVisua11y() {
+    const htmlClasses = document.documentElement.classList;
+
+    if (htmlClasses.contains('a11y-no-animations')) {
+      // Stop on last frame
+      this.goToEndAndStop();
+    }
   }
 
   remove() {

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -213,7 +213,6 @@ export default class SvgView extends ComponentView {
     const animation = this.model.get('_animation');
     animation._autoPlay = false;
     animation._showPauseControl = false;
-
     const lastFrame = this.animation.totalFrames - 1;
     this.toggleControls();
     this.animation.goToAndStop(lastFrame, true);

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -222,10 +222,10 @@ export default class SvgView extends ComponentView {
     const showPauseControl = animation._showPauseControl;
     this.$('.svg__playpause').toggle(showPauseControl);
 
-    if (!showPauseControl) {
-      // Remove click event
-      this.undelegateEvents();
-    }
+    if (showPauseControl) return;
+
+    // Remove click event
+    this.undelegateEvents();
   }
 
   remove() {

--- a/js/svg-view.js
+++ b/js/svg-view.js
@@ -110,10 +110,7 @@ export default class SvgView extends ComponentView {
     const isReducedMotion = (this.model.get('_isReducedMotionSupportEnabled') && this._reducedMotionQuery && this._reducedMotionQuery.matches);
     const animation = this.model.get('_animation');
     if (isReducedMotion) {
-      animation._autoPlay = false;
-      this.model.set('_animation', animation);
-      this.animation.goToAndStop(this.animation.firstFrame + this.animation.totalFrames - 1, true);
-      this.update();
+      this.goToEndAndStop();
       return;
     }
     animation._autoPlay = this.model.get('_originalAutoplay');
@@ -202,19 +199,32 @@ export default class SvgView extends ComponentView {
   }
 
   goToEndAndStop() {
-    // const lastFrame = this.animation.totalFrames - 1;
-    // this.animation.loop = 0;
-    // this.animation.goToAndStop(lastFrame, true);
-    // this.showControls = false;
-    // this.pause();
+    const animation = this.model.get('_animation');
+    const lastFrame = this.animation.totalFrames - 1;
+    animation._autoPlay = false;
+    animation._showPauseControl = false;
+    this.toggleControls();
+    this.animation.goToAndStop(lastFrame, true);
+    this.animation.pause();
+    this.update();
   }
 
   checkVisua11y() {
     const htmlClasses = document.documentElement.classList;
+    if (!htmlClasses.contains('a11y-no-animations')) return;
 
-    if (htmlClasses.contains('a11y-no-animations')) {
-      // Stop on last frame
-      this.goToEndAndStop();
+    // Stop on last frame
+    this.goToEndAndStop();
+  }
+
+  toggleControls() {
+    const animation = this.model.get('_animation');
+    const showPauseControl = animation._showPauseControl;
+    this.$('.svg__playpause').toggle(showPauseControl);
+
+    if (!showPauseControl) {
+      // Remove click event
+      this.undelegateEvents();
     }
   }
 

--- a/less/svg.less
+++ b/less/svg.less
@@ -30,8 +30,11 @@
   }
 
   &.is-svg-paused .svg__playpause {
-    opacity: 0;
     .icon-video-play;
+  }
+
+  &.is-svg-paused.hide-controls .svg__playpause {
+    visibility: hidden;
   }
 
   html:not(.touch) &.is-svg-playing .svg__player:hover .svg__playpause,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-svg",
   "version": "4.0.1",
-  "framework": ">=5.8",
+  "framework": ">=5.31.27",
   "homepage": "https://github.com/cgkineo/adapt-svg",
   "issues": "https://github.com/cgkineo/adapt-svg/issues",
   "component": "svg",


### PR DESCRIPTION
Fixes #21 

### Fix
* Adds support for Visua11y's "no animations" option. Requires framework **v5.31.27** due to the DOM Element Modification API dependency
* Fixes issue when using `"_playFirstViewOnly": true` and scrolling off and back again. The frame displayed when back on screen was blank. May not be an issue (see notes).

### Notes
For some reason, I needed to subtract one from the total frames in order to go to the last frame.

```
this.animation.totalFrames - 1
```

This was causing an issue with `_playFirstViewOnly` which has been fixed. It would be good to know if the problem was with the specific `.svgz` [file](https://lottiefiles.com/animations/cube-shape-animation-k69Xropjds) that I was using, or if others can reproduce the same issue.

In any case, would it be safer to just stop at the 2nd to last frame in case any given `.svgz` file has the same issue? I don't know how often this issue comes up.